### PR TITLE
fix: moment import

### DIFF
--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -1,5 +1,5 @@
 import { parseUnits, toBeHex } from 'ethers';
-import { duration } from 'moment';
+import moment from 'moment';
 import { constants } from 'starknet';
 import {
   BuildSwapTransaction,
@@ -303,7 +303,7 @@ export const aDCACreateOrder = (): CreateOrderDto => ({
   sellAmount: toBeHex(parseUnits('1', 18)),
   buyTokenAddress: '0x72df4dc5b6c4df72e4288857317caf2ce9da166ab8719ab8306516a2fddfff7',
   sellAmountPerCycle: toBeHex(parseUnits('1', 18)),
-  frequency: duration('1'),
+  frequency: moment.duration('1'),
   pricingStrategy: {
     tokenToMinAmount: toBeHex(parseUnits('1', 18)),
     tokenToMaxAmount: toBeHex(parseUnits('1', 18)),


### PR DESCRIPTION
# Problem
When building my Vite app I am getting this error:
```
Build failed in 1.50s
error during build:
node_modules/.pnpm/@avnu+avnu-sdk@3.1.0_ethers@6.15.0_moment@2.30.1_qs@6.14.0_starknet@7.6.4/node_modules/@avnu/avnu-sdk/dist/index.mjs (186:9): "duration" is not exported by "node_modules/.pnpm/moment@2.30.1/node_modules/moment/dist/moment.js", imported by "node_modules/.pnpm/@avnu+avnu-sdk@3.1.0_ethers@6.15.0_moment@2.30.1_qs@6.14.0_starknet@7.6.4/node_modules/@avnu/avnu-sdk/dist/index.mjs".
```
TLDR `"duration" is not exported by "moment"`

### Note
This is not a problem for older versions of Vite, but newer ones are more strict and will fail the build.