### PR TITLE
:memo: Update outdated SwapCalls references to AvnuCalls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ getQuotes(request: QuoteRequest, options?: AvnuOptions): Promise<Quote[]>
 Get best optimized quotes from on-chain and off-chain liquidity, sorted by best first.
 
 ```typescript
-quoteToCalls(params: QuoteToCallsParams, options?: AvnuOptions): Promise<SwapCalls>
+quoteToCalls(params: QuoteToCallsParams, options?: AvnuOptions): Promise<AvnuCalls>
 ```
 Build Starknet calls from a quote, including approval and slippage handling.
 
@@ -104,7 +104,7 @@ Calculate min/max amounts with slippage (slippage as decimal: 0.01 = 1%).
 - `QuoteRequest`: sellTokenAddress, buyTokenAddress, sellAmount, takerAddress, size
 - `Quote`: routes, sellAmount, buyAmount, sellAmountInUsd, buyAmountInUsd, priceImpact, gasFeesInUsd
 - `Route`: percent, sellAmount, buyAmount, routes (sub-routes)
-- `SwapCalls`: calls, approvalCalls, contractAddress, calldata
+- `AvnuCalls`: chainId, calls
 
 ---
 
@@ -602,7 +602,7 @@ buildImpulseUrl(path: string): string   // IMPULSE_BASE_URL/v3{path}
 ```typescript
 // Swap fixtures
 aQuote(), aQuoteRequest(), aPrice(), aPriceRequest()
-aSwapCalls(), anInvokeTransactionResponse(), aCall()
+aAvnuCalls(), anInvokeTransactionResponse(), aCall()
 ethToken(), btcToken(), aPage<T>(), aSource()
 
 // DCA fixtures

--- a/src/swap.services.spec.ts
+++ b/src/swap.services.spec.ts
@@ -126,7 +126,7 @@ describe('Swap services', () => {
   });
 
   describe('quoteToCalls', () => {
-    it('should return a SwapCalls', async () => {
+    it('should return AvnuCalls', async () => {
       // Given
       const response = aAvnuCalls();
       fetchMock.post(`${BASE_URL}/swap/${SWAP_API_VERSION}/build`, response);

--- a/src/swap.services.ts
+++ b/src/swap.services.ts
@@ -61,7 +61,7 @@ const getQuotes = (request: QuoteRequest, options?: AvnuOptions): Promise<Quote[
  * @param params.slippage The maximum acceptable slippage of the buyAmount amount (required)
  * @param params.executeApprove If true, the response will contain the approve call. True by default
  * @param options Optional SDK configuration
- * @returns The SwapCalls containing the calls to execute the trade and the chainId
+ * @returns The AvnuCalls containing the calls to execute the trade and the chainId
  */
 const quoteToCalls = (params: QuoteToCallsParams, options?: AvnuOptions): Promise<AvnuCalls> => {
   const { quoteId, takerAddress, slippage, executeApprove } = params;


### PR DESCRIPTION
Replace all remaining references to the deprecated SwapCalls type with the current AvnuCalls type across documentation and source files.