### PR TITLE
fix(utils): forward abort signal + harden parseResponse

### DIFF
--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,42 @@
+import { ContractError } from './types';
+import { parseResponse, postRequest } from './utils';
+
+describe('utils', () => {
+  describe('postRequest', () => {
+    it('should forward abortSignal into RequestInit.signal', () => {
+      const controller = new AbortController();
+      const init = postRequest({ hello: 'world' }, { abortSignal: controller.signal });
+      expect(init.signal).toBe(controller.signal);
+    });
+
+    it('should set ask-signature header when avnuPublicKey is provided (even empty string)', () => {
+      const init = postRequest(undefined, { avnuPublicKey: '' });
+      expect((init.headers as Record<string, string>)['ask-signature']).toBe('true');
+    });
+  });
+
+  describe('parseResponse', () => {
+    it('should throw a default error message if 500 response contains no messages', async () => {
+      const response = new Response(JSON.stringify({ messages: [], revertError: undefined }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      await expect(parseResponse(response)).rejects.toStrictEqual(new Error('Internal server error'));
+    });
+
+    it('should throw ContractError when 500 response message includes "Contract error"', async () => {
+      const mkResponse = () =>
+        new Response(JSON.stringify({ messages: ['Contract error: revert'], revertError: '0x123' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+
+      await expect(parseResponse(mkResponse())).rejects.toBeInstanceOf(ContractError);
+      await expect(parseResponse(mkResponse())).rejects.toMatchObject({
+        message: 'Contract error: revert',
+        revertError: '0x123',
+      });
+    });
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,10 +15,11 @@ export const getRequest = (options?: AvnuOptions): RequestInit => ({
 });
 export const postRequest = (body: unknown, options?: AvnuOptions): RequestInit => ({
   method: 'POST',
+  signal: options?.abortSignal,
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json',
-    ...(options?.avnuPublicKey && { 'ask-signature': 'true' }),
+    ...(options?.avnuPublicKey !== undefined && { 'ask-signature': 'true' }),
   },
   ...(body !== undefined && { body: JSON.stringify(body) }),
 });
@@ -33,16 +34,17 @@ export const postRequest = (body: unknown, options?: AvnuOptions): RequestInit =
 export const parseResponse = <T>(response: Response, avnuPublicKey?: string): Promise<T> => {
   if (response.status === 400) {
     return response.json().then((error: RequestError) => {
-      throw new Error(error.messages[0]);
+      const message = error?.messages?.[0] ?? 'Bad request';
+      throw new Error(message);
     });
   }
   if (response.status === 500) {
     return response.json().then((error: RequestError) => {
-      if (error.messages.length >= 0 && error.messages[0].includes('Contract error')) {
-        throw new ContractError(error.messages[0], error.revertError || '');
-      } else {
-        throw new Error(error.messages[0]);
+      const message = error?.messages?.[0] ?? 'Internal server error';
+      if (message.includes('Contract error')) {
+        throw new ContractError(message, error?.revertError || '');
       }
+      throw new Error(message);
     });
   }
   if (response.status > 400) {


### PR DESCRIPTION
### What
- Forward `abortSignal` to `postRequest` (previously only `getRequest` supported cancellation).
- Harden `parseResponse` for 400/500 cases:
  - handle empty `messages` arrays
  - fix contract-error detection (`messages.length >= 0` was always true)
- Add Jest unit tests for both changes.

### Why
- SDK consumers expect request cancellation to work consistently for GET and POST.
- Current 500 handler can throw due to `messages[0]` being undefined.

### Tests
- `npm test`
