### PR TITLE
:wrench: Upgrade npm in publish workflow for Trusted Publishers support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: yarn
       - name: Install dependencies


### PR DESCRIPTION
Node 22 ships with npm v10 but Trusted Publishers OIDC requires npm >= 11.5.1.