### PR TITLE
✨ Add noteId parameter to quoteToCalls for private swap builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avnu/avnu-sdk",
-  "version": "4.1.0-next.0",
+  "version": "4.1.0-next.1",
   "description": "TypeScript SDK for building exchange functionality on Layers 2 with the AVNU API",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/swap.services.ts
+++ b/src/swap.services.ts
@@ -64,10 +64,13 @@ const getQuotes = (request: QuoteRequest, options?: AvnuOptions): Promise<Quote[
  * @returns The AvnuCalls containing the calls to execute the trade and the chainId
  */
 const quoteToCalls = (params: QuoteToCallsParams, options?: AvnuOptions): Promise<AvnuCalls> => {
-  const { quoteId, takerAddress, slippage, executeApprove } = params;
+  const { quoteId, takerAddress, slippage, executeApprove, noteId } = params;
   return fetch(
     `${getBaseUrl(options)}/swap/${SWAP_API_VERSION}/build`,
-    postRequest({ quoteId, takerAddress, slippage, includeApprove: executeApprove }, options),
+    postRequest(
+      { quoteId, takerAddress, slippage, includeApprove: executeApprove, ...(noteId && { noteId }) },
+      options,
+    ),
   ).then((response) => parseResponse<AvnuCalls>(response, options?.avnuPublicKey));
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,7 @@ export interface QuoteToCallsParams {
   slippage: number;
   takerAddress?: string;
   executeApprove?: boolean;
+  noteId?: string;
 }
 
 export interface Source {


### PR DESCRIPTION
## Summary
- Add optional `noteId` to `QuoteToCallsParams`, passed to the `/swap/v3/build` endpoint to associate a swap with a privacy pool note
- No breaking changes — `noteId` is optional and only sent when provided

## Changes
- `src/types.ts`: add `noteId?: string` to `QuoteToCallsParams`
- `src/swap.services.ts`: spread `noteId` into the build request body

## Test plan
- [x] Verified on Sepolia with a private swap flow (getQuotes → quoteToCalls with noteId → execute via paymaster)
- [x] Classic swap without noteId still works as before