### PR TITLE
♻️ Replace noteId with private boolean in quoteToCalls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avnu/avnu-sdk",
-  "version": "4.1.0-next.1",
+  "version": "4.1.0-next.2",
   "description": "TypeScript SDK for building exchange functionality on Layers 2 with the AVNU API",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/swap.services.ts
+++ b/src/swap.services.ts
@@ -64,11 +64,11 @@ const getQuotes = (request: QuoteRequest, options?: AvnuOptions): Promise<Quote[
  * @returns The AvnuCalls containing the calls to execute the trade and the chainId
  */
 const quoteToCalls = (params: QuoteToCallsParams, options?: AvnuOptions): Promise<AvnuCalls> => {
-  const { quoteId, takerAddress, slippage, executeApprove, noteId } = params;
+  const { quoteId, takerAddress, slippage, executeApprove, private: isPrivate } = params;
   return fetch(
     `${getBaseUrl(options)}/swap/${SWAP_API_VERSION}/build`,
     postRequest(
-      { quoteId, takerAddress, slippage, includeApprove: executeApprove, ...(noteId && { noteId }) },
+      { quoteId, takerAddress, slippage, includeApprove: executeApprove, ...(isPrivate && { private: true }) },
       options,
     ),
   ).then((response) => parseResponse<AvnuCalls>(response, options?.avnuPublicKey));

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,7 @@ export interface InvokeSwapParams extends InvokeParams {
 export interface AvnuCalls {
   chainId: string;
   calls: Call[];
+  executorAddress?: string;
 }
 
 export interface QuoteRequest {
@@ -193,7 +194,7 @@ export interface QuoteToCallsParams {
   slippage: number;
   takerAddress?: string;
   executeApprove?: boolean;
-  noteId?: string;
+  private?: boolean;
 }
 
 export interface Source {


### PR DESCRIPTION
- quoteToCalls now accepts `private: boolean` instead of `noteId: string`
- Response includes `executorAddress` when private=true
- Bump version to 4.1.0-next.2