### PR TITLE
chore(deps): support starknet.js v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "peerDependencies": {
     "ethers": "^6.15.0",
-    "starknet": "^8.9.1 || ^9.0.0"
+    "starknet": "^10.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "7.28.5",
@@ -77,7 +77,7 @@
     "jest": "29.7.0",
     "knip": "^5.82.1",
     "node-fetch": "2",
-    "starknet": "9.2.1",
+    "starknet": "10.4.0",
     "prettier": "3.6.2",
     "size-limit": "12.0.0",
     "tsup": "8.5.1",

--- a/src/swap.services.ts
+++ b/src/swap.services.ts
@@ -92,7 +92,7 @@ const quoteToCalls = (params: QuoteToCallsParams, options?: AvnuOptions): Promis
 const executeSwap = async (params: InvokeSwapParams, options?: AvnuOptions): Promise<InvokeTransactionResponse> => {
   const { provider, paymaster, quote, executeApprove = true, slippage } = params;
 
-  const chainId = await provider.getChainId();
+  const chainId = await provider.provider.getChainId();
   if (chainId !== quote.chainId) {
     throw Error(`Invalid chainId`);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,6 +2292,16 @@
     "@size-limit/file" "12.0.0"
     size-limit "12.0.0"
 
+"@starknet-io/get-starknet-wallet-standard-v6@npm:@starknet-io/get-starknet-wallet-standard@6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-6.0.2.tgz#b3efa7dc713409c7a87db51406f169f2b8c7a1dd"
+  integrity sha512-jCnLFNPw4IGgmkwDlHszKbnyEbQKu3pE7cZHyVMFwyvRG98IA9FZKykrTNH7Nq3BILf6EcOZ5SgYUQE/gtqraA==
+  dependencies:
+    "@starknet-io/types-js" "^0.10.3"
+    "@wallet-standard/base" "^1.1.1"
+    "@wallet-standard/features" "^1.1.1"
+    ox "^0.4.4"
+
 "@starknet-io/get-starknet-wallet-standard@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0.tgz#15af5193b657bf225cf9a0ad10ded67e6329cc46"
@@ -2302,15 +2312,25 @@
     "@wallet-standard/features" "^1.1.0"
     ox "^0.4.4"
 
-"@starknet-io/starknet-types-010@npm:@starknet-io/types-js@0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.10.0.tgz#cc6c270ce392bb2a8c460464f8192d413772f150"
-  integrity sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==
+"@starknet-io/starknet-types-0101@npm:@starknet-io/types-js@0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.10.2.tgz#f86a246d46ea7bdc6b29ce19b0f3c4458c87697a"
+  integrity sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog==
 
-"@starknet-io/starknet-types-09@npm:@starknet-io/types-js@~0.9.1":
+"@starknet-io/starknet-types-0103@npm:@starknet-io/types-js@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.10.3.tgz#724476fe89bd7be2c30954d253b7dd718c16a47f"
+  integrity sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==
+
+"@starknet-io/starknet-types-09@npm:@starknet-io/types-js@~0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.9.2.tgz#08a794a35f2785878812ebd151a261399900b594"
   integrity sha512-vWOc0FVSn+RmabozIEWcEny1I73nDGTvOrLYJsR1x7LGA3AZmqt4i/aW69o/3i2NN5CVP8Ok6G1ayRQJKye3Wg==
+
+"@starknet-io/types-js@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.10.3.tgz#724476fe89bd7be2c30954d253b7dd718c16a47f"
+  integrity sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==
 
 "@starknet-io/types-js@^0.7.10":
   version "0.7.10"
@@ -2547,12 +2567,24 @@
   resolved "https://registry.yarnpkg.com/@wallet-standard/base/-/base-1.1.0.tgz#214093c0597a1e724ee6dbacd84191dfec62bb33"
   integrity sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==
 
+"@wallet-standard/base@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/base/-/base-1.1.1.tgz#29ee1071bb96ddfe3f27d99f3be84b63f803f37d"
+  integrity sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==
+
 "@wallet-standard/features@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@wallet-standard/features/-/features-1.1.0.tgz#f256d7b18940c8d134f66164330db358a8f5200e"
   integrity sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==
   dependencies:
     "@wallet-standard/base" "^1.1.0"
+
+"@wallet-standard/features@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/features/-/features-1.1.1.tgz#0c7c12f01842727d1899371a551f8f423199efee"
+  integrity sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==
+  dependencies:
+    "@wallet-standard/base" "^1.1.1"
 
 abi-wan-kanabi@2.2.4:
   version "2.2.4"
@@ -5662,11 +5694,6 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
-pako@^2.0.4:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
-  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -6267,22 +6294,22 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-starknet@9.2.1:
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/starknet/-/starknet-9.2.1.tgz#9c9c28109708a86d393a684251d28ffa19e6f3bf"
-  integrity sha512-bFJY2sMZ9tsLBhPCm719MWjoz+doabXIwPX/xtW56EHwAJMRAS6mICF6H2dCwOQHJmCMKpOSFBwW0SaiHzcioQ==
+starknet@10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/starknet/-/starknet-10.4.0.tgz#93ec5438a285dd20d2e1b805ad89b0d0c21c871c"
+  integrity sha512-HoI53jf9DqqjoIz7APWdDoarhSbiD+Y1RpsWhvSOq4QBC838bbdzSWPH8nmoeF3JhmWmW01J/9c7/eEqAcqlWA==
   dependencies:
     "@noble/curves" "~1.7.0"
     "@noble/hashes" "~1.6.0"
     "@scure/base" "~1.2.1"
     "@scure/starknet" "1.1.0"
     "@starknet-io/get-starknet-wallet-standard" "^5.0.0"
-    "@starknet-io/starknet-types-010" "npm:@starknet-io/types-js@0.10.0"
-    "@starknet-io/starknet-types-09" "npm:@starknet-io/types-js@~0.9.1"
+    "@starknet-io/get-starknet-wallet-standard-v6" "npm:@starknet-io/get-starknet-wallet-standard@6.0.2"
+    "@starknet-io/starknet-types-0101" "npm:@starknet-io/types-js@0.10.2"
+    "@starknet-io/starknet-types-0103" "npm:@starknet-io/types-js@0.10.3"
+    "@starknet-io/starknet-types-09" "npm:@starknet-io/types-js@~0.9.2"
     abi-wan-kanabi "2.2.4"
     lossless-json "^4.2.0"
-    pako "^2.0.4"
-    ts-mixer "^6.0.3"
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -6554,11 +6581,6 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
-
-ts-mixer@^6.0.3:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.4.tgz#1da39ceabc09d947a82140d9f09db0f84919ca28"
-  integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
 
 tsconfig-paths@^3.15.0:
   version "3.15.0"


### PR DESCRIPTION
Widen the starknet peer range to include ^10 and build/test against 10.4.0. Fix executeSwap: getChainId() moved off AccountInterface in v10 — read it from account.provider (ProviderInterface).