### PR TITLE
feat(privacy): add STRK20 wallet prover (createStrk20WalletProver + buildStrk20Actions)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avnu/avnu-sdk",
-  "version": "4.2.0-next.2",
+  "version": "4.2.0-next.3",
   "description": "TypeScript SDK for building exchange functionality on Layers 2 with the AVNU API",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/privacy.services.spec.ts
+++ b/src/privacy.services.spec.ts
@@ -1,8 +1,24 @@
 import fetchMock from 'fetch-mock';
+import type { STRK20_CALL_AND_PROOF } from 'starknet';
 import { hash } from 'starknet';
 import { BASE_URL, PAYMASTER_BASE_URL, SWAP_API_VERSION } from './constants';
-import { aCall, aPrivacyProof, aPrivateFeeMode, aPrivateSwapCallAndProof, aQuote } from './fixtures';
-import { buildPrivateSwapFee, executePrivateSwap, submitPrivateSwap, toPaymasterCall } from './privacy.services';
+import {
+  aCall,
+  aPrivacyProof,
+  aPrivateFeeMode,
+  aPrivateSwapCallAndProof,
+  aPrivateSwapFee,
+  aPrivateSwapPlan,
+  aQuote,
+} from './fixtures';
+import {
+  buildPrivateSwapFee,
+  buildStrk20Actions,
+  createStrk20WalletProver,
+  executePrivateSwap,
+  submitPrivateSwap,
+  toPaymasterCall,
+} from './privacy.services';
 import { createMockPrivateSwapProver } from './test-utils';
 
 describe('Privacy services', () => {
@@ -309,6 +325,84 @@ describe('Privacy services', () => {
         new Error('Private swap requires an executorAddress from quoteToCalls (ensure private swap is enabled)'),
       );
       expect(prover.buildAndProve).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('buildStrk20Actions', () => {
+    it('should materialize the plan as withdraw sell, withdraw fee, open note, invoke executor', () => {
+      // Given
+      const plan = aPrivateSwapPlan({
+        sellTokenAddress: '0x123',
+        sellAmount: 1000000000000000000n,
+        buyTokenAddress: '0x456',
+        executorAddress: '0x789',
+        executorCalls: [aCall({ contractAddress: '0xdead', entrypoint: 'execute_swap', calldata: ['0x1', '0x2'] })],
+        fee: aPrivateSwapFee({ token: '0xabc', recipient: '0xfeerecipient', amount: 500n }),
+        takerAddress: '0x7a',
+      });
+
+      // When
+      const actions = buildStrk20Actions(plan);
+
+      // Then
+      // fromCallsToExecuteCalldata_cairo1: [n_calls, to, selector('execute_swap'), calldata_len, ...calldata]
+      expect(actions).toStrictEqual([
+        { type: 'withdraw', token: '0x123', amount: '0xde0b6b3a7640000', recipient: '0x789' },
+        { type: 'withdraw', token: '0xabc', amount: '0x1f4', recipient: '0xfeerecipient' },
+        { type: 'transfer', token: '0x456', amount: 'OPEN', recipient: '0x7a' },
+        {
+          type: 'invoke',
+          contract: '0x789',
+          calldata: [
+            '0x456',
+            '0x1',
+            '0xdead',
+            '0x2838190fef3088d277dd6581e49b92f66a21df03d0442e81d31ac1147cc6048',
+            '0x2',
+            '0x1',
+            '0x2',
+            '${openNoteIds[0]}',
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('createStrk20WalletProver', () => {
+    it('should prove the actions with the wallet and map the artifact to PrivateSwapCallAndProof', async () => {
+      // Given
+      const plan = aPrivateSwapPlan();
+      const walletArtifact: STRK20_CALL_AND_PROOF = {
+        call: { contract_address: '0x11', entry_point: 'apply_actions', calldata: ['0x1'] },
+        proof: { data: 'proof-data', output: ['0x2'], proof_facts: ['0x3'] },
+      };
+      const account = { strk20PrepareInvoke: jest.fn().mockResolvedValue(walletArtifact) };
+
+      // When
+      const result = await createStrk20WalletProver(account).buildAndProve(plan);
+
+      // Then
+      expect(account.strk20PrepareInvoke).toHaveBeenCalledWith(buildStrk20Actions(plan));
+      expect(result).toStrictEqual({
+        call: { contractAddress: '0x11', entrypoint: 'apply_actions', calldata: ['0x1'] },
+        proof: { data: 'proof-data', proofFacts: ['0x3'] },
+      });
+    });
+
+    it('should default missing wallet calldata to an empty array', async () => {
+      // Given
+      const account = {
+        strk20PrepareInvoke: jest.fn().mockResolvedValue({
+          call: { contract_address: '0x11', entry_point: 'apply_actions' },
+          proof: { data: '', output: [], proof_facts: [] },
+        }),
+      };
+
+      // When
+      const result = await createStrk20WalletProver(account).buildAndProve(aPrivateSwapPlan());
+
+      // Then
+      expect(result.call.calldata).toStrictEqual([]);
     });
   });
 

--- a/src/privacy.services.ts
+++ b/src/privacy.services.ts
@@ -1,4 +1,5 @@
-import { Call, hash } from 'starknet';
+import type { STRK20_ACTION } from 'starknet';
+import { Call, hash, num, transaction } from 'starknet';
 import { quoteToCalls } from './swap.services';
 import {
   AvnuOptions,
@@ -8,11 +9,20 @@ import {
   PaymasterCall,
   PrivateFeeMode,
   PrivateSwapFee,
+  PrivateSwapPlan,
+  PrivateSwapProver,
+  Strk20ProverAccount,
   SubmitPrivateSwapParams,
 } from './types';
 import { getPaymasterBaseUrl } from './utils';
 
 const PAYMASTER_PARAMETERS_VERSION = '0x1';
+
+// Wallet-resolved placeholder expanding to the id of the note opened for the bought token
+const OPEN_NOTE_ID_PLACEHOLDER = '${openNoteIds[0]}';
+
+// STRK20 felts are hex strings; amounts and serialized calldata are normalized accordingly
+const toFelt = (value: string | bigint): string => num.toHex(value);
 
 interface JsonRpcResponse<T> {
   result?: T;
@@ -123,6 +133,71 @@ const submitPrivateSwap = (
   ).then(({ transaction_hash }) => ({ transactionHash: transaction_hash }));
 
 /**
+ * Translate a `PrivateSwapPlan` into the STRK20 action vocabulary: withdraw the
+ * sell amount to the executor, withdraw the pool fee to its recipient, open a
+ * note for the bought token, then invoke the executor with the serialized swap
+ * calls (the executor expects `[buyToken, ...calls, openNoteId]`).
+ *
+ * Use it directly when driving `wallet_strk20PrepareInvoke` yourself; prefer
+ * `createStrk20WalletProver` for the ready-made `PrivateSwapProver`.
+ *
+ * @param plan The backend-neutral private swap plan. See `PrivateSwapPlan`
+ * @returns The STRK20 actions to prove with a STRK20-capable wallet
+ */
+const buildStrk20Actions = (plan: PrivateSwapPlan): STRK20_ACTION[] => [
+  {
+    type: 'withdraw',
+    token: plan.sellTokenAddress,
+    amount: toFelt(plan.sellAmount),
+    recipient: plan.executorAddress,
+  },
+  {
+    type: 'withdraw',
+    token: plan.fee.token,
+    amount: toFelt(plan.fee.amount),
+    recipient: plan.fee.recipient,
+  },
+  {
+    type: 'transfer',
+    token: plan.buyTokenAddress,
+    amount: 'OPEN',
+    recipient: plan.takerAddress,
+  },
+  {
+    type: 'invoke',
+    contract: plan.executorAddress,
+    calldata: [
+      plan.buyTokenAddress,
+      ...transaction.fromCallsToExecuteCalldata_cairo1(plan.executorCalls).map(toFelt),
+      OPEN_NOTE_ID_PLACEHOLDER,
+    ],
+  },
+];
+
+/**
+ * Create a `PrivateSwapProver` backed by a STRK20-capable wallet (starknet.js
+ * `WalletAccountV6` / `wallet_strk20PrepareInvoke`). The wallet keeps the keys
+ * and notes and generates the proof; the prover only describes actions and maps
+ * the wallet artifact to the `PrivateSwapCallAndProof` shape.
+ *
+ * @param account The STRK20-capable account (e.g. a connected wallet exposing `strk20PrepareInvoke`)
+ * @returns A prover to inject into `executePrivateSwap`
+ */
+const createStrk20WalletProver = (account: Strk20ProverAccount): PrivateSwapProver => ({
+  buildAndProve: async (plan) => {
+    const { call, proof } = await account.strk20PrepareInvoke(buildStrk20Actions(plan));
+    return {
+      call: {
+        contractAddress: call.contract_address,
+        entrypoint: call.entry_point,
+        calldata: call.calldata ?? [],
+      },
+      proof: { data: proof.data, proofFacts: proof.proof_facts },
+    };
+  },
+});
+
+/**
  * Execute a private swap end to end.
  *
  * Orchestrates the four steps of the private swap flow while keeping all
@@ -142,7 +217,8 @@ const submitPrivateSwap = (
  * @param params.takerAddress The address of the trader
  * @param params.poolAddress The privacy pool contract address
  * @param params.feeMode The `sponsored_private` fee configuration
- * @param params.prover The injected proof provider. The SDK never handles keys or notes
+ * @param params.prover The injected proof provider. The SDK never handles keys or notes.
+ *                      For STRK20 wallets, use `createStrk20WalletProver(account)`
  * @param params.paymasterApiKey Optional paymaster API key (server-side only)
  * @param options Optional SDK configuration
  * @returns The transaction hash
@@ -184,4 +260,11 @@ const executePrivateSwap = async (
   return submitPrivateSwap({ callAndProof, feeMode, paymasterApiKey }, options);
 };
 
-export { buildPrivateSwapFee, executePrivateSwap, submitPrivateSwap, toPaymasterCall };
+export {
+  buildPrivateSwapFee,
+  buildStrk20Actions,
+  createStrk20WalletProver,
+  executePrivateSwap,
+  submitPrivateSwap,
+  toPaymasterCall,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { OutsideExecutionTypedData } from '@starknet-io/starknet-types-09';
 import type { Duration } from 'moment';
+import type { STRK20_ACTION, STRK20_CALL_AND_PROOF } from 'starknet';
 import { AccountInterface, Call, ExecutionParameters, PaymasterInterface } from 'starknet';
 import { DcaOrderStatus, DcaTradeStatus, FeedDateRange, FeedResolution, PriceFeedType, SourceType } from './enums';
 
@@ -212,6 +213,14 @@ export interface PrivateSwapPlan {
  */
 export interface PrivateSwapProver {
   buildAndProve(plan: PrivateSwapPlan): Promise<PrivateSwapCallAndProof>;
+}
+
+/**
+ * The STRK20 privacy wallet API surface needed to prove a private swap
+ * (starknet.js `WalletAccountV6` / `wallet_strk20PrepareInvoke`).
+ */
+export interface Strk20ProverAccount {
+  strk20PrepareInvoke(actions: STRK20_ACTION[], simulate?: boolean): Promise<STRK20_CALL_AND_PROOF>;
 }
 
 export interface BuildPrivateSwapFeeParams {


### PR DESCRIPTION
## Why

Every integrator proving private swaps with a STRK20-capable wallet currently has to hand-write the same two pieces: the `PrivateSwapPlan` → STRK20 actions mapping (including the non-obvious `${openNoteIds[0]}` placeholder and the cairo1 call serialization) and the wallet artifact → `PrivateSwapCallAndProof` mapping. This already exists in avnu-frontend and a partner team just asked how to write it. The wallet backend is the overwhelmingly common case, so the SDK should ship it.

## What

- `buildStrk20Actions(plan)`: translates the plan into the STRK20 action vocabulary — withdraw the sell amount to the executor, withdraw the pool fee to its recipient, open a note for the bought token, then invoke the executor with `[buyToken, ...serializedCalls, openNoteId]`. Exported for integrators driving `wallet_strk20PrepareInvoke` themselves.
- `createStrk20WalletProver(account)`: ready-made `PrivateSwapProver` backed by `strk20PrepareInvoke` (starknet.js `WalletAccountV6`). Wallet integration becomes one line:

  ```ts
  const prover = createStrk20WalletProver(account);
  ```

- `Strk20ProverAccount`: the minimal wallet surface required.

The action mapping is ported as-is from avnu-frontend's `wallet-prover.ts` (battle-tested in the private swap PRs). The SDK still never touches keys, notes, or proofs — the wallet does all the cryptography.

## Tests

- `buildStrk20Actions` asserted against the hardcoded serialization already validated in avnu-frontend
- `createStrk20WalletProver` artifact mapping + missing-calldata default
- 98 tests pass, `yarn lint` and `yarn knip` clean

Docs PR: avnu-labs/docs-v2#18
