### PR TITLE
feat(privacy): preserve paymaster RPC error data with typed PaymasterRpcError

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avnu/avnu-sdk",
-  "version": "4.2.0-next.3",
+  "version": "4.2.0-next.4",
   "description": "TypeScript SDK for building exchange functionality on Layers 2 with the AVNU API",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/privacy.services.spec.ts
+++ b/src/privacy.services.spec.ts
@@ -20,6 +20,7 @@ import {
   toPaymasterCall,
 } from './privacy.services';
 import { createMockPrivateSwapProver } from './test-utils';
+import { PaymasterRpcError } from './types';
 
 describe('Privacy services', () => {
   beforeEach(() => {
@@ -120,7 +121,7 @@ describe('Privacy services', () => {
       // When & Then
       expect.assertions(1);
       await expect(buildPrivateSwapFee({ poolAddress: '0xpool', feeMode })).rejects.toEqual(
-        new Error('Paymaster paymaster_buildTransaction: pool not found (code: -32000)'),
+        new PaymasterRpcError('paymaster_buildTransaction', 'pool not found', -32000),
       );
     });
   });
@@ -179,8 +180,34 @@ describe('Privacy services', () => {
       // When & Then
       expect.assertions(1);
       await expect(submitPrivateSwap({ callAndProof, feeMode })).rejects.toEqual(
-        new Error('Paymaster paymaster_executeTransaction: invalid proof (code: -32001)'),
+        new PaymasterRpcError('paymaster_executeTransaction', 'invalid proof', -32001),
       );
+    });
+
+    it('should preserve transaction execution error data', async () => {
+      // Given
+      const feeMode = aPrivateFeeMode();
+      const callAndProof = aPrivateSwapCallAndProof();
+      const data = {
+        execution_error: {
+          contract_address: '0xcontract',
+          class_hash: '0xclass',
+          selector: '0xselector',
+          error: 'Insufficient tokens received',
+        },
+      };
+      fetchMock.post(PAYMASTER_BASE_URL, {
+        error: { code: 156, message: 'An error occurred (TRANSACTION_EXECUTION_ERROR)', data },
+      });
+
+      // When & Then
+      expect.assertions(1);
+      await expect(submitPrivateSwap({ callAndProof, feeMode })).rejects.toMatchObject({
+        name: 'PaymasterRpcError',
+        method: 'paymaster_executeTransaction',
+        code: 156,
+        data,
+      });
     });
   });
 

--- a/src/privacy.services.ts
+++ b/src/privacy.services.ts
@@ -7,6 +7,7 @@ import {
   ExecutePrivateSwapParams,
   InvokeTransactionResponse,
   PaymasterCall,
+  PaymasterRpcError,
   PrivateFeeMode,
   PrivateSwapFee,
   PrivateSwapPlan,
@@ -53,7 +54,7 @@ const paymasterRpcCall = <T>(
     .then((response) => response.json() as Promise<JsonRpcResponse<T>>)
     .then((json) => {
       if (json.error) {
-        throw new Error(`Paymaster ${method}: ${json.error.message} (code: ${json.error.code})`);
+        throw new PaymasterRpcError(method, json.error.message, json.error.code, json.error.data);
       }
       return json.result as T;
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,18 @@ export class ContractError extends Error {
   }
 }
 
+export class PaymasterRpcError extends Error {
+  constructor(
+    public readonly method: string,
+    message: string,
+    public readonly code: number,
+    public readonly data?: unknown,
+  ) {
+    super(`Paymaster ${method}: ${message} (code: ${code})`);
+    this.name = 'PaymasterRpcError';
+  }
+}
+
 /* Paymaster Part */
 
 export interface PaymasterParams {


### PR DESCRIPTION
## Why

The privacy paymaster returns generic JSON-RPC messages (`An error occurred (TRANSACTION_EXECUTION_ERROR) (code: 156)`) with the actual revert reason only in the error `data` field ([paymaster `From<Error> for ErrorObject`](https://github.com/avnu-labs/paymaster/blob/main/crates/paymaster-rpc/src/lib.rs)):

- code 156 `TRANSACTION_EXECUTION_ERROR` → `data = { execution_error }` (SNIP-29 recursive shape)
- code 163 `UNKNOWN_ERROR` → `data` is a plain string (e.g. `"service not available"`)
- code 169 `MAX_L2_GAS_AMOUNT_EXCEEDED` → `data` is the detail message

`paymasterRpcCall` threw a plain `Error` built from the message only, dropping that data — consumers could not surface or map the real failure cause.

## What

- New `PaymasterRpcError` (exported from `types.ts`, mirrors `ContractError` style) carrying `method`, `code` and `data`
- `paymasterRpcCall` throws it instead of a plain `Error`

## Compatibility

The error message format is unchanged (`Paymaster <method>: <message> (code: <N>)`), so message-matching consumers are unaffected. Purely additive — fits the 4.2.0-next cycle.

## Tests

- New spec: `data` (nested `execution_error`) is preserved on the thrown error
- Existing rejection specs upgraded to assert the typed error
- `yarn lint`, `yarn test` (99 ✔), `yarn build` all green