### PR TITLE
chore: start 4.2.1 next cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avnu/avnu-sdk",
-  "version": "4.2.0",
+  "version": "4.2.1-next.0",
   "description": "TypeScript SDK for building exchange functionality on Layers 2 with the AVNU API",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Opens the prerelease cycle on `develop` after the 4.2.0 release: `4.2.0` -> `4.2.1-next.0`.

This step was missed after #322 (`chore: release 4.2.0`), which left `develop` on a plain `4.2.0`. As a result the first CI step — *Validate prerelease version on develop* — rejected **every** incoming PR in ~4 seconds, before `knip`/`lint`/`test`/`build` ever ran:

```
##[error]Version '4.2.0' on develop must contain '-next' (e.g. 4.1.0-next.0).
```

That is what turned dependabot PRs #324-#328 red on 2026-07-20, and #332 red yesterday. This PR passes the gate itself (`4.2.1-next.0` contains `-next`), so it unblocks the branch on merge.

**Why patch and not minor:** everything landed on `develop` since 4.2.0 is a bug fix (#331) plus devDependency bumps (#332). No public API change, no consumer-visible impact.

Follows the same convention as 1392d6b (`chore: start 4.2.0 next cycle`).

## Verification

`yarn knip`, `yarn lint`, `yarn test` (105/105) and `yarn build` all pass locally, and the version gate was simulated locally against the exact workflow condition.