### PR TITLE
fix(dca): validate the orders page-size limit

### DIFF
--- a/src/dca.services.spec.ts
+++ b/src/dca.services.spec.ts
@@ -37,6 +37,40 @@ describe('DCA services', () => {
       expect(result).toStrictEqual(expected);
     });
 
+    it('should forward the maximum page size', async () => {
+      // Given
+      const response = aPage([]);
+      const url = `${BASE_URL}/dca/${DCA_API_VERSION}/orders?traderAddress=0x0&size=25`;
+      fetchMock.get(url, response);
+
+      // When
+      await getDcaOrders({ traderAddress: '0x0', size: 25 });
+
+      // Then
+      expect(fetchMock.called(url)).toBe(true);
+    });
+
+    it('should reject a page size above the API limit before sending a request', async () => {
+      // When & Then
+      await expect(getDcaOrders({ traderAddress: '0x0', size: 26 })).rejects.toEqual(
+        new Error('DCA order page size must not exceed 25'),
+      );
+      expect(fetchMock.calls()).toHaveLength(0);
+    });
+
+    it('should preserve the default page size when size is omitted', async () => {
+      // Given
+      const response = aPage([]);
+      const url = `${BASE_URL}/dca/${DCA_API_VERSION}/orders?traderAddress=0x0`;
+      fetchMock.get(url, response);
+
+      // When
+      await getDcaOrders({ traderAddress: '0x0' });
+
+      // Then
+      expect(fetchMock.called(url)).toBe(true);
+    });
+
     it.each([
       { name: 'no', pricingStrategy: {} },
       { name: 'only a minimum', pricingStrategy: { tokenToMinAmount: '0x1' } },

--- a/src/dca.services.ts
+++ b/src/dca.services.ts
@@ -15,12 +15,14 @@ import {
 } from './types';
 import { getBaseUrl, getRequest, parseResponse, parseResponseWithSchema, postRequest } from './utils';
 
+const MAX_DCA_ORDERS_PAGE_SIZE = 25;
+
 /**
  * Get the DCA orders for a given trader
  * @param params.traderAddress The trader address
  * @param params.status The status of the orders (ACTIVE, CLOSED, INDEXING)
  * @param params.page The page number
- * @param params.size The page size
+ * @param params.size The page size (maximum 25)
  * @param params.sort The sort order
  * @param options Optional SDK configuration
  * @returns The page of DCA orders corresponding to the request params
@@ -29,6 +31,10 @@ const getDcaOrders = async (
   { traderAddress, status, page, size, sort }: GetDcaOrdersParams,
   options?: AvnuOptions,
 ): Promise<Page<DcaOrder>> => {
+  if (size !== undefined && size > MAX_DCA_ORDERS_PAGE_SIZE) {
+    throw new Error(`DCA order page size must not exceed ${MAX_DCA_ORDERS_PAGE_SIZE}`);
+  }
+
   const params = qs.stringify({ traderAddress, status, page, size, sort }, { arrayFormat: 'repeat' });
 
   return fetch(`${getBaseUrl(options)}/dca/${DCA_API_VERSION}/orders?${params}`, getRequest(options)).then((response) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -418,6 +418,12 @@ export interface Apr {
 export interface GetDcaOrdersParams extends Pageable {
   traderAddress: string;
   status?: DcaOrderStatus;
+  /**
+   * Number of DCA orders to return per page.
+   *
+   * The DCA API accepts a maximum page size of 25.
+   */
+  size?: number;
 }
 
 export interface PricingStrategy {


### PR DESCRIPTION
## Summary

- document the DCA orders endpoint's 25-order page-size cap
- reject values above 25 before making a network request
- keep the limit DCA-specific until the other paginated endpoints are confirmed

## Why

The API returns a raw `400 Size is too high` response for `size >= 26`. Failing locally gives callers an actionable limit and avoids an unnecessary round trip.

This intentionally preserves the endpoint's existing behavior for lower values and does not attempt to solve the inlined-trade payload problem, which requires API support.

Addresses the SDK-side part of #330.

## Verification

- `npm test` (108 tests)
- focused DCA suite (16 tests)
- `npx tsc --noEmit`
- scoped ESLint and Prettier checks
- CJS, ESM, browser IIFE, and declaration builds
- `git diff --check`