### PR TITLE
feat: expose Starknet execution details

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 // Using npm
 npm install @avnu/avnu-sdk
 
-// or yarn 
+// or yarn
 yarn add @avnu/avnu-sdk
 ```
 
@@ -72,6 +72,26 @@ await executeSwap({
 });
 ```
 
+### Custom transaction fees
+
+Direct swap, DCA, and staking executions accept Starknet.js `UniversalDetails`. For example, you can set an
+explicit tip while keeping resource bound estimation automatic:
+
+```typescript
+await executeSwap({
+  quote: quotes[0],
+  slippage: 0.01,
+  provider: account,
+  executionDetails: {
+    tip: 0n, // FRI per L2 gas unit
+  },
+});
+```
+
+You can also provide `resourceBounds` through `executionDetails`. These details cannot be combined with an active
+paymaster. When using `WalletAccount`, the connected wallet retains final control over transaction fees and may not
+apply these details.
+
 ## Documentation
 
 For complete documentation, examples, and API reference, visit:
@@ -82,4 +102,3 @@ For complete documentation, examples, and API reference, visit:
 
 - Node.js >= 22
 - Starknet.js >= 10.0.0
-

--- a/src/dca.services.spec.ts
+++ b/src/dca.services.spec.ts
@@ -144,14 +144,15 @@ describe('DCA services', () => {
       const mockAccount = createMockAccount('0x0user');
       const order = aDCACreateOrder();
       const avnuCalls = aAvnuCalls();
+      const executionDetails = { tip: 1n };
       fetchMock.post(`${BASE_URL}/dca/${DCA_API_VERSION}/orders`, avnuCalls);
 
       // When
-      const result = await executeCreateDca({ provider: mockAccount, order });
+      const result = await executeCreateDca({ provider: mockAccount, order, executionDetails });
 
       // Then
       expect(result).toStrictEqual({ transactionHash: '0xabc' });
-      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls);
+      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls, executionDetails);
     });
 
     it('should execute with paymaster', async () => {
@@ -182,14 +183,15 @@ describe('DCA services', () => {
       const mockAccount = createMockAccount('0x0user');
       const orderAddress = '0x0order';
       const avnuCalls = aAvnuCalls();
+      const executionDetails = { tip: 1n };
       fetchMock.post(`${BASE_URL}/dca/${DCA_API_VERSION}/orders/${orderAddress}/cancel`, avnuCalls);
 
       // When
-      const result = await executeCancelDca({ provider: mockAccount, orderAddress });
+      const result = await executeCancelDca({ provider: mockAccount, orderAddress, executionDetails });
 
       // Then
       expect(result).toStrictEqual({ transactionHash: '0xabc' });
-      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls);
+      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls, executionDetails);
     });
 
     it('should execute with paymaster', async () => {

--- a/src/dca.services.ts
+++ b/src/dca.services.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 import { DCA_API_VERSION } from './constants';
-import { executeAllPaymasterFlow } from './paymaster.services';
+import { executeCalls } from './execute';
 import { DcaOrderSchema, PageSchema } from './schemas';
 import {
   AvnuCalls,
@@ -97,14 +97,9 @@ const executeCreateDca = async (
   params: InvokeCreateDcaParams,
   options?: AvnuOptions,
 ): Promise<InvokeTransactionResponse> => {
-  const { provider, paymaster, order } = params;
+  const { order } = params;
   const { calls } = await createDcaToCalls(order, options);
-
-  if (paymaster && paymaster.active) {
-    return executeAllPaymasterFlow({ paymaster, provider, calls });
-  }
-  const result = await provider.execute(calls);
-  return { transactionHash: result.transaction_hash };
+  return executeCalls(params, calls);
 };
 
 /**
@@ -122,15 +117,9 @@ const executeCancelDca = async (
   params: InvokeCancelDcaParams,
   options?: AvnuOptions,
 ): Promise<InvokeTransactionResponse> => {
-  const { provider, paymaster, orderAddress } = params;
+  const { orderAddress } = params;
   const { calls } = await cancelDcaToCalls(orderAddress, options);
-
-  if (paymaster && paymaster.active) {
-    return executeAllPaymasterFlow({ paymaster, provider, calls });
-  }
-
-  const result = await provider.execute(calls);
-  return { transactionHash: result.transaction_hash };
+  return executeCalls(params, calls);
 };
 
 export { cancelDcaToCalls, createDcaToCalls, executeCancelDca, executeCreateDca, getDcaOrders };

--- a/src/execute.spec.ts
+++ b/src/execute.spec.ts
@@ -1,0 +1,64 @@
+import { executeCalls } from './execute';
+import { aAvnuCalls } from './fixtures';
+import { createMockAccount, createMockPaymaster, mockExecutionParams } from './test-utils';
+
+describe('executeCalls', () => {
+  it('should preserve the existing execute call when execution details are omitted', async () => {
+    const account = createMockAccount();
+    const { calls } = aAvnuCalls();
+
+    const result = await executeCalls({ provider: account }, calls);
+
+    expect(result).toStrictEqual({ transactionHash: '0xabc' });
+    expect(account.execute).toHaveBeenCalledWith(calls);
+  });
+
+  it('should forward execution details unchanged', async () => {
+    const account = createMockAccount();
+    const { calls } = aAvnuCalls();
+    const executionDetails = { tip: 1n };
+
+    await executeCalls({ provider: account, executionDetails }, calls);
+
+    expect(account.execute).toHaveBeenCalledWith(calls, executionDetails);
+    expect(account.execute.mock.calls[0][1]).toBe(executionDetails);
+  });
+
+  it('should forward execution details when the paymaster is inactive', async () => {
+    const account = createMockAccount();
+    const paymaster = createMockPaymaster();
+    const { calls } = aAvnuCalls();
+    const executionDetails = { tip: 1n };
+
+    await executeCalls(
+      {
+        provider: account,
+        executionDetails,
+        paymaster: { active: false, provider: paymaster, params: mockExecutionParams },
+      },
+      calls,
+    );
+
+    expect(account.execute).toHaveBeenCalledWith(calls, executionDetails);
+    expect(paymaster.buildTransaction).not.toHaveBeenCalled();
+  });
+
+  it('should reject execution details with an active paymaster', async () => {
+    const account = createMockAccount();
+    const paymaster = createMockPaymaster();
+    const { calls } = aAvnuCalls();
+
+    await expect(
+      executeCalls(
+        {
+          provider: account,
+          executionDetails: { tip: 1n },
+          paymaster: { active: true, provider: paymaster, params: mockExecutionParams },
+        },
+        calls,
+      ),
+    ).rejects.toThrow('executionDetails cannot be used with an active paymaster');
+    expect(account.execute).not.toHaveBeenCalled();
+    expect(paymaster.buildTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -1,0 +1,21 @@
+import type { Call } from 'starknet';
+import { executeAllPaymasterFlow } from './paymaster.services';
+import type { InvokeParams, InvokeTransactionResponse } from './types';
+
+const executeCalls = async (
+  { provider, paymaster, executionDetails }: InvokeParams,
+  calls: Call[],
+): Promise<InvokeTransactionResponse> => {
+  if (paymaster?.active) {
+    if (executionDetails !== undefined) {
+      throw new Error('executionDetails cannot be used with an active paymaster');
+    }
+    return executeAllPaymasterFlow({ paymaster, provider, calls });
+  }
+
+  const result =
+    executionDetails === undefined ? await provider.execute(calls) : await provider.execute(calls, executionDetails);
+  return { transactionHash: result.transaction_hash };
+};
+
+export { executeCalls };

--- a/src/staking.services.spec.ts
+++ b/src/staking.services.spec.ts
@@ -335,17 +335,18 @@ describe('Staking services', () => {
       const poolAddress = '0x0pool';
       const amount = parseUnits('100', 18);
       const avnuCalls = aAvnuCalls();
+      const executionDetails = { tip: 1n };
       fetchMock.post(
         `${BASE_URL}/staking/${STAKING_API_VERSION}/pools/${poolAddress}/members/0x0user/stake`,
         avnuCalls,
       );
 
       // When
-      const result = await executeStake({ provider: mockAccount, poolAddress, amount });
+      const result = await executeStake({ provider: mockAccount, poolAddress, amount, executionDetails });
 
       // Then
       expect(result).toStrictEqual({ transactionHash: '0xabc' });
-      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls);
+      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls, executionDetails);
     });
 
     it('should execute with paymaster', async () => {
@@ -382,17 +383,23 @@ describe('Staking services', () => {
       const poolAddress = '0x0pool';
       const amount = parseUnits('100', 18);
       const avnuCalls = aAvnuCalls();
+      const executionDetails = { tip: 1n };
       fetchMock.post(
         `${BASE_URL}/staking/${STAKING_API_VERSION}/pools/${poolAddress}/members/0x0user/initiate-withdraw`,
         avnuCalls,
       );
 
       // When
-      const result = await executeInitiateUnstake({ provider: mockAccount, poolAddress, amount });
+      const result = await executeInitiateUnstake({
+        provider: mockAccount,
+        poolAddress,
+        amount,
+        executionDetails,
+      });
 
       // Then
       expect(result).toStrictEqual({ transactionHash: '0xabc' });
-      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls);
+      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls, executionDetails);
     });
 
     it('should execute with paymaster', async () => {
@@ -428,17 +435,18 @@ describe('Staking services', () => {
       const mockAccount = createMockAccount('0x0user');
       const poolAddress = '0x0pool';
       const avnuCalls = aAvnuCalls();
+      const executionDetails = { tip: 1n };
       fetchMock.post(
         `${BASE_URL}/staking/${STAKING_API_VERSION}/pools/${poolAddress}/members/0x0user/claim-withdraw`,
         avnuCalls,
       );
 
       // When
-      const result = await executeUnstake({ provider: mockAccount, poolAddress });
+      const result = await executeUnstake({ provider: mockAccount, poolAddress, executionDetails });
 
       // Then
       expect(result).toStrictEqual({ transactionHash: '0xabc' });
-      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls);
+      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls, executionDetails);
     });
 
     it('should execute with paymaster', async () => {
@@ -473,17 +481,23 @@ describe('Staking services', () => {
       const poolAddress = '0x0pool';
       const restake = true;
       const avnuCalls = aAvnuCalls();
+      const executionDetails = { tip: 1n };
       fetchMock.post(
         `${BASE_URL}/staking/${STAKING_API_VERSION}/pools/${poolAddress}/members/0x0user/claim-rewards`,
         avnuCalls,
       );
 
       // When
-      const result = await executeClaimRewards({ provider: mockAccount, poolAddress, restake });
+      const result = await executeClaimRewards({
+        provider: mockAccount,
+        poolAddress,
+        restake,
+        executionDetails,
+      });
 
       // Then
       expect(result).toStrictEqual({ transactionHash: '0xabc' });
-      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls);
+      expect(mockAccount.execute).toHaveBeenCalledWith(avnuCalls.calls, executionDetails);
     });
 
     it('should execute with paymaster', async () => {

--- a/src/staking.services.ts
+++ b/src/staking.services.ts
@@ -1,6 +1,6 @@
 import { toBeHex } from 'ethers';
 import { STAKING_API_VERSION } from './constants';
-import { executeAllPaymasterFlow } from './paymaster.services';
+import { executeCalls } from './execute';
 import { StakingInfoSchema, UserStakingInfoSchema } from './schemas';
 import {
   AvnuCalls,
@@ -137,12 +137,9 @@ const claimRewardsToCalls = async (params: ClaimRewardsToCallsParams, options?: 
  * @returns The transaction hash
  */
 const executeStake = async (params: InvokeStakeParams, options?: AvnuOptions): Promise<InvokeTransactionResponse> => {
-  const { provider, paymaster, poolAddress, amount } = params;
+  const { provider, poolAddress, amount } = params;
   const { calls } = await stakeToCalls({ poolAddress, userAddress: provider.address, amount }, options);
-  if (paymaster && paymaster.active) {
-    return executeAllPaymasterFlow({ paymaster, provider, calls });
-  }
-  return provider.execute(calls).then((result) => ({ transactionHash: result.transaction_hash }));
+  return executeCalls(params, calls);
 };
 
 /**
@@ -161,12 +158,9 @@ const executeInitiateUnstake = async (
   params: InvokeInitiateUnstakeParams,
   options?: AvnuOptions,
 ): Promise<InvokeTransactionResponse> => {
-  const { provider, paymaster, poolAddress, amount } = params;
+  const { provider, poolAddress, amount } = params;
   const { calls } = await initiateUnstakeToCalls({ poolAddress, userAddress: provider.address, amount }, options);
-  if (paymaster && paymaster.active) {
-    return executeAllPaymasterFlow({ paymaster, provider, calls });
-  }
-  return provider.execute(calls).then((result) => ({ transactionHash: result.transaction_hash }));
+  return executeCalls(params, calls);
 };
 
 /**
@@ -184,12 +178,9 @@ const executeUnstake = async (
   params: InvokeUnstakeParams,
   options?: AvnuOptions,
 ): Promise<InvokeTransactionResponse> => {
-  const { provider, paymaster, poolAddress } = params;
+  const { provider, poolAddress } = params;
   const { calls } = await unstakeToCalls({ poolAddress, userAddress: provider.address }, options);
-  if (paymaster && paymaster.active) {
-    return executeAllPaymasterFlow({ paymaster, provider, calls });
-  }
-  return provider.execute(calls).then((result) => ({ transactionHash: result.transaction_hash }));
+  return executeCalls(params, calls);
 };
 
 /**
@@ -208,12 +199,9 @@ const executeClaimRewards = async (
   params: InvokeClaimRewardsParams,
   options?: AvnuOptions,
 ): Promise<InvokeTransactionResponse> => {
-  const { provider, paymaster, poolAddress, restake } = params;
+  const { provider, poolAddress, restake } = params;
   const { calls } = await claimRewardsToCalls({ poolAddress, userAddress: provider.address, restake }, options);
-  if (paymaster && paymaster.active) {
-    return executeAllPaymasterFlow({ paymaster, provider, calls });
-  }
-  return provider.execute(calls).then((result) => ({ transactionHash: result.transaction_hash }));
+  return executeCalls(params, calls);
 };
 
 export {

--- a/src/swap.services.spec.ts
+++ b/src/swap.services.spec.ts
@@ -6,10 +6,12 @@ import { aAvnuCalls, aQuote, aQuoteRequest, aSource } from './fixtures';
 import {
   calculateMaxSpendAmount,
   calculateMinReceivedAmount,
+  executeSwap,
   getQuotes,
   getSources,
   quoteToCalls,
 } from './swap.services';
+import { createMockAccount } from './test-utils';
 
 describe('Swap services', () => {
   beforeEach(() => {
@@ -160,6 +162,26 @@ describe('Swap services', () => {
       expect(quoteToCalls({ quoteId: '', takerAddress: '', slippage: 0.01 })).rejects.toEqual(
         Error('401 Unauthorized'),
       );
+    });
+  });
+
+  describe('executeSwap', () => {
+    it('should forward execution details', async () => {
+      const account = createMockAccount();
+      const quote = aQuote();
+      const avnuCalls = aAvnuCalls();
+      const executionDetails = { tip: 1n };
+      fetchMock.post(`${BASE_URL}/swap/${SWAP_API_VERSION}/build`, avnuCalls);
+
+      const result = await executeSwap({
+        provider: account,
+        quote,
+        slippage: 0.01,
+        executionDetails,
+      });
+
+      expect(result).toStrictEqual({ transactionHash: '0xabc' });
+      expect(account.execute).toHaveBeenCalledWith(avnuCalls.calls, executionDetails);
     });
   });
 

--- a/src/swap.services.ts
+++ b/src/swap.services.ts
@@ -2,7 +2,7 @@ import { toBeHex } from 'ethers';
 import qs from 'qs';
 import { z } from 'zod';
 import { SWAP_API_VERSION } from './constants';
-import { executeAllPaymasterFlow } from './paymaster.services';
+import { executeCalls } from './execute';
 import { QuoteSchema, SourceSchema } from './schemas';
 import {
   AvnuCalls,
@@ -91,7 +91,7 @@ const quoteToCalls = (params: QuoteToCallsParams, options?: AvnuOptions): Promis
  * @returns The transaction hash
  */
 const executeSwap = async (params: InvokeSwapParams, options?: AvnuOptions): Promise<InvokeTransactionResponse> => {
-  const { provider, paymaster, quote, executeApprove = true, slippage } = params;
+  const { provider, quote, executeApprove = true, slippage } = params;
 
   const chainId = await provider.provider.getChainId();
   if (chainId !== quote.chainId) {
@@ -103,12 +103,7 @@ const executeSwap = async (params: InvokeSwapParams, options?: AvnuOptions): Pro
     options,
   );
 
-  if (paymaster && paymaster.active) {
-    return executeAllPaymasterFlow({ paymaster, provider, calls });
-  }
-
-  const result = await provider.execute(calls);
-  return { transactionHash: result.transaction_hash };
+  return executeCalls(params, calls);
 };
 
 /**

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,5 +1,5 @@
 import { OutsideExecutionTypedData } from '@starknet-io/starknet-types-09';
-import { AccountInterface, ExecutionParameters, PaymasterInterface } from 'starknet';
+import { AccountInterface, constants, ExecutionParameters, PaymasterInterface } from 'starknet';
 import { aPrivateSwapCallAndProof } from './fixtures';
 import { PrivateSwapProver } from './types';
 
@@ -13,6 +13,9 @@ export const mockExecutionParams = {
 export const createMockAccount = (address = '0x123'): jest.Mocked<AccountInterface> =>
   ({
     address,
+    provider: {
+      getChainId: jest.fn().mockResolvedValue(constants.StarknetChainId.SN_SEPOLIA),
+    },
     execute: jest.fn().mockResolvedValue({ transaction_hash: '0xabc' }),
     signMessage: jest.fn().mockResolvedValue(['0x1', '0x2']),
   }) as unknown as jest.Mocked<AccountInterface>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { OutsideExecutionTypedData } from '@starknet-io/starknet-types-09';
 import type { Duration } from 'moment';
-import type { STRK20_ACTION, STRK20_CALL_AND_PROOF } from 'starknet';
+import type { STRK20_ACTION, STRK20_CALL_AND_PROOF, UniversalDetails } from 'starknet';
 import { AccountInterface, Call, ExecutionParameters, PaymasterInterface } from 'starknet';
 import { DcaOrderStatus, DcaTradeStatus, FeedDateRange, FeedResolution, PriceFeedType, SourceType } from './enums';
 
@@ -72,6 +72,8 @@ export interface InvokeTransactionResponse {
 export interface InvokeParams {
   provider: AccountInterface;
   paymaster?: InvokePaymasterParams;
+  /** Starknet transaction details forwarded to AccountInterface.execute. Cannot be used with an active paymaster. */
+  executionDetails?: UniversalDetails;
 }
 
 /* Error Part */


### PR DESCRIPTION
## Summary

- expose optional Starknet.js `UniversalDetails` through every direct `execute*` helper
- forward execution details unchanged while preserving the existing one-argument execution path
- reject execution details when the AVNU paymaster is active
- document custom fee controls and wallet-account limitations

## Validation

- `yarn test` (110 tests)
- `yarn lint`
- `yarn build`

Closes #339